### PR TITLE
Use https by default instead of http

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ New instance of context can be created with the seetings to use, or can be loade
 There is a default instance of the context (MapsApiContext.Default) which by default will try to load from config app settings or use default value per setting.  
 Default settings' values:
 ``` csharp
-DefaultGeocodeApiUrl = "http://maps.google.com/maps/api/geocode/json?";
+DefaultGeocodeApiUrl = "https://maps.google.com/maps/api/geocode/json?";
 DefaultAutoRetry = true;
 DefaultRetryDelay = 100;// in milliseconds
 DefaultRetryTimes = 5;
@@ -109,7 +109,7 @@ A sample config app settings:
 <configuration>
     <appSettings>
         <add key="GoogleMaps.ApiKey" value="API_KEY"/>
-        <!--next is optional, by default http://maps.google.com/maps/api/geocode/json? will be used-->
+        <!--next is optional, by default https://maps.google.com/maps/api/geocode/json? will be used-->
         <add key="GoogleMaps.GeocodeApiUrl" value="API_URL"/>
         <add key="GoogleMaps.AutoRetry" value="true"/>
         <add key="GoogleMaps.RetryDelay" value="100"/>

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Install-Package Google.Maps.Client
 #### Address Geocoding Request
 
 ```csharp
-GeoRequest request = new GeoRequest("plovdiv bulgaria");
-GeoResponse response = request.GetResponse();
-// GeoResponse response = request.GetResponseAsync();
-GeoLocation location = response.Results[0].Geometry.Location;
+GeocodingRequest request = new GeocodingRequest("plovdiv bulgaria");
+GeocodingResponse response = request.GetResponse();
+// GeocodingResponse response = request.GetResponseAsync();
+LatLng location = response.Results[0].Geometry.Location;
 double latitude = location.Latitude;
 double longitude = location.Longitude;
 // TODO use latitude/longitude values}}
@@ -69,8 +69,8 @@ double longitude = location.Longitude;
 #### Reverse Geocoding Request
 
 ```csharp
-GeoRequest request = new GeoRequest(42.1438409, 24.7495615);
-GeoResponse response = request.GetResponse();
+GeocodingRequest request = new GeocodingRequest(42.1438409, 24.7495615);
+GeocodingResponse response = request.GetResponse();
 string address = response.Results[0].FormattedAddress;
 // TODO use address values
 ```
@@ -81,14 +81,14 @@ Builds for all .NET frameworks support async request/response now.
 
 ```csharp
 // NET35 & NET40 async get request
-GeoRequest request = new GeoRequest("plovdiv bulgaria");
-GeoResponse response = request.GetResponseAsync();
+GeocodingRequest request = new GeocodingRequest("plovdiv bulgaria");
+GeocodingResponse response = request.GetResponseAsync();
 ```
 
 ```csharp
 // NET45 async get request
-GeoRequest request = new GeoRequest("plovdiv bulgaria");
-GeoResponse response = await request.GetResponseAsync();
+GeocodingRequest request = new GeocodingRequest("plovdiv bulgaria");
+GeocodingResponse response = await request.GetResponseAsync();
 ```
 
 ### Context

--- a/src/Client/MapsApiContext.cs
+++ b/src/Client/MapsApiContext.cs
@@ -20,7 +20,7 @@ namespace Velyo.Google.Services
         /// </summary>
         public static readonly MapsApiContext Default = Load();
 
-        internal const string DefaultGeocodeApiUrl = "http://maps.google.com/maps/api/geocode/json?";
+        internal const string DefaultGeocodeApiUrl = "https://maps.google.com/maps/api/geocode/json?";
 
         internal const bool DefaultAutoRetry = true;
         internal const int DefaultRetryDelay = 100;// in milliseconds


### PR DESCRIPTION
Google requires https when using an API Key and responds with this error message if you use http:
> Requests to this API must be over SSL. Load the API with "https://" instead of "http://".

I also updated the README with the current class names.

| Old name    | New name          |
|-------------|-------------------|
| GeoRequest  | GeocodingRequest  |
| GeoResponse | GeocodingResponse |
| GeoLocation | LatLng            |